### PR TITLE
Issue #9: Application name is wrong in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextn",
+  "name": "weather-contribution-app",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
Update `package.json` file name property from `nextn` to `weather-contribution-app`

## Changements apportés
- Correction of the app name in package.json file

## Tests  
- [x] J'ai relu les modifications
- [x] Les liens fonctionnent correctement
- [x] Le formatage Markdown est correct

Résout l'issue #9 